### PR TITLE
Add Marionette block

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -14,6 +14,11 @@ then
   npm install backbone@"$BACKBONE"
 fi
 
+if [[ -n "$MARIONETTE" ]]
+then
+  npm install backbone.marionette@"$MARIONETTE"
+fi
+
 if [[ -n "$LODASH" ]]
 then
   npm install lodash@"$LODASH"


### PR DESCRIPTION
This allows us to install different versions of marionette. Useful for testing other libs that want to test multiple versions of marionette, such as the inspector. 

fixes #1
