### PR TITLE
Use cp instead of mv for lodash

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -26,8 +26,8 @@ then
   # Lodash@2 and Lodash@3 have different file structures
   if [[ "$LODASH" < "3.0" ]]
   then
-    mv node_modules/lodash/lodash.js node_modules/underscore/underscore.js
-  else 
-    mv node_modules/lodash/index.js node_modules/underscore/underscore.js
+    cp node_modules/lodash/lodash.js node_modules/underscore/underscore.js
+  else
+    cp node_modules/lodash/index.js node_modules/underscore/underscore.js
   fi
 fi


### PR DESCRIPTION
Resolves #3

Previously lodash is getting moved so if the library (or in npm 3 any dependency) loaded lodash, it was getting moved and was no longer available.

With this we just have to pray no dep requires an underscore incompatible with the lodash version in testing.

Success: https://travis-ci.org/paulfalgout/backbone.marionette/jobs/88592334
