### PR TITLE
Create mn-com-deploy.sh

### DIFF
--- a/mn-com-deploy.sh
+++ b/mn-com-deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+echo "$TRAVIS_BRANCH"
+
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]
+then
+  git clone https://github.com/marionettejs/marionettejs.com
+  cd marionettejs.com
+  sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  npm run setup
+  npm i
+  echo "Deploying!"
+  bower i
+  npm run compile-all
+  cp CNAME dist
+  cd dist
+  git init
+  git config user.email "travis@marionettejs.com"
+  git config user.name "TRAVIS-CI"
+  git add .
+  git commit -m "deploy"
+  git push --force --quiet "https://${GH_TOKEN}@github.com/marionettejs/marionettejs.com.git" master:gh-pages > /dev/null 2>&1
+fi


### PR DESCRIPTION
Here some script for deploying site `mn.com`after merging stuff to `marionettejs` master. This one is based on [travis-runner.sh](https://github.com/marionettejs/marionettejs.com/blob/master/travis-runner.sh). I'm not sure if it'll work 100% precent. Maybe someone has ideas how to test it or other way.

P.S. Sorry guys that I created branch is scope of `marionettejs/travis-ci-setup` instead of fork.
