### PR TITLE
Stop moving lodash over underscore

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -21,12 +21,4 @@ fi
 if [[ -n "$LODASH" ]]
 then
   npm install lodash@"$LODASH"
-
-  # lodash 2 lodash 3 and lodash 4 have different file structures
-  if [[ "$LODASH" < "3.0" ]] || [[ "$LODASH" > "4.0" ]] || [[ "$LODASH" == "4.0" ]]
-  then
-    cp node_modules/lodash/lodash.js node_modules/underscore/underscore.js
-  else
-    cp node_modules/lodash/index.js node_modules/underscore/underscore.js
-  fi
 fi


### PR DESCRIPTION
Resolves #5

This isn't going to work with npm v3+ because of its flat file structure.  Testing with lodash installed will have to be handled intelligently by the test setup itself.
